### PR TITLE
[BOJ 15686] 드래곤 커브

### DIFF
--- a/boj/15685.java
+++ b/boj/15685.java
@@ -1,0 +1,71 @@
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static int N, x, y, d, g;
+    static int[] dy = {0, -1, 0, 1};
+    static int[] dx = {1, 0, -1, 0};
+  	static int[][] map;
+  	static int cnt = 0;
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+		map = new int[101][101];
+		StringTokenizer st;
+        for(int i = 0 ; i < N ; i++) {
+			st = new StringTokenizer(br.readLine());
+			x = Integer.parseInt(st.nextToken());
+			y = Integer.parseInt(st.nextToken());
+			d = Integer.parseInt(st.nextToken());
+			g = Integer.parseInt(st.nextToken());
+			
+			makeCurve();
+        }
+		
+		count();
+		System.out.print(cnt);
+		
+        
+    }
+	
+	static void makeCurve() {
+		
+		List<Integer> l = new ArrayList<>();
+		l.add(d);
+		
+		for(int i = 1 ; i <= g ; i++) {
+			for(int j = (int)Math.pow(2,i-1)-1 ; j >= 0 ; j--) {
+				int nd = l.get(j) + 1;
+				if(nd > 3) nd = 0;
+				
+				l.add(nd);
+			}
+		}
+		
+		map[y][x] = 1;
+		for(int dir : l) {
+			int nx = x + dx[dir];
+			int ny = y + dy[dir];
+		
+			map[ny][nx] = 1;
+			x = nx; y = ny;
+		}
+	}
+	
+	static void count() {
+		for(int i = 0 ; i < 100 ; i++) {
+			for(int j = 0 ; j < 100 ; j++) {
+				if(map[i][j] == 1 && map[i+1][j] == 1
+				  && map[i][j+1] == 1 && map[i+1][j+1] == 1) cnt++;
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
문제에는 드래곤 커브가 이전 세대의 드래곤 커브를 90도 시계 방향 회전 시킨 다음, 그것을 끝 점에 붙인다고 되어있다. 코드로 구현해야 하기 때문에 규칙성을 찾아야 한다.

이전 세대의 드래곤 커브와 연관이 있다는 점을 활용하였다. 이전 세대의 드래곤 커브를 Stack에 넣는다 생각했을 때, 새로 추가되는 선분들은 Stack에서 꺼내 반시계 방향으로 진행 방향을 꺼내 이어 붙이는 것이다. 예를 들어

- 0세대: d=0
- 1세대: {0, 1}
    - 이전 세대 {0}
    - 이전 세대 역으로 꺼내기 {0}
    - 이전 세대 반시계 방향 회전 {1}
- 2세대: {0, 1, 2, 1}
    - 이전 세대 {0, 1}
    - 이전 세대 역으로 꺼내기 {1, 0}
    - 이전 세대 반시계 방향 회전 {2, 1}
- 3세대: {0, 1, 2, 1, 2, 3, 2, 1}
    - 이전 세대 {0, 1, 2, 1}
    - 이전 세대 역으로 꺼내기 {1, 2, 1, 0}
    - 이전 세대 반시계 방향 회전 {2, 3, 2, 1}

실제 내가 구현할 때는 stack보다 list에 for문을 활용하는게 더 편할 거 같아 list로 구현했다. 입력 받은 경우의 드래곤 커브를 모두 격자에 추가 시켜주고 네 꼭짓점이 모두 `1`이라면 (드래곤 커브의 일부) `결과값+1` 해주면 된다.